### PR TITLE
Make code build on OS X

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,5 @@ dormann_d65c01.bin.gz
 dormann_d65c10.bin.gz
 dormann_d65c11.bin.gz
 extended_tests.zip
-
+/.dir-locals.el
+decode6502.dSYM/

--- a/build.sh
+++ b/build.sh
@@ -1,9 +1,24 @@
 #!/bin/bash
 
 LIBS="-lm"
+INCS=""
+DEFS=""
 
 if [[ $OS = *"Windows"* ]]; then
   LIBS="$LIBS -largp"
+  DEFS="-D_GNU_SOURCE"
+elif [[ `uname` = Darwin ]]; then
+  if [ -f /opt/local/include/argp.h ]; then
+    # MacPorts packages required: argp-standalone
+    LIBS="$LIBS -L/opt/local/lib -largp"
+    INCS="$INCS -I/opt/local/include"
+
+    # (MacPorts md5sha1sum required for tests)
+  else
+    echo "argp not found - but will try building anyway"
+  fi
+else
+  DEFS="-D_GNU_SOURCE"
 fi
 
-gcc -Wall -O3 -D_GNU_SOURCE -o decode6502 src/main.c src/em_6502.c src/profiler.c src/profiler_instr.c src/profiler_block.c src/profiler_call.c src/tube_decode.c $LIBS
+gcc -Wall -O3 -g $DEFS $INCS -o decode6502 src/main.c src/em_6502.c src/profiler.c src/profiler_instr.c src/profiler_block.c src/profiler_call.c src/tube_decode.c src/musl_tsearch.c $LIBS

--- a/src/musl_tsearch.c
+++ b/src/musl_tsearch.c
@@ -1,0 +1,221 @@
+/* musl as a whole is licensed under the following standard MIT license: */
+
+/* ---------------------------------------------------------------------- */
+/* Copyright © 2005-2020 Rich Felker, et al. */
+
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the */
+/* "Software"), to deal in the Software without restriction, including */
+/* without limitation the rights to use, copy, modify, merge, publish, */
+/* distribute, sublicense, and/or sell copies of the Software, and to */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions: */
+
+/* The above copyright notice and this permission notice shall be */
+/* included in all copies or substantial portions of the Software. */
+
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. */
+/* ---------------------------------------------------------------------- */
+
+#include <stdlib.h>
+#include "musl_tsearch.h"
+
+/* AVL tree height < 1.44*log2(nodes+2)-0.3, MAXH is a safe upper bound.  */
+#define MAXH (sizeof(void*)*8*3/2)
+
+struct node {
+	const void *key;
+	void *a[2];
+	int h;
+};
+
+void ttdestroy(void *root, void (*freekey)(void *))
+{
+	struct node *r = root;
+
+	if (r == 0)
+		return;
+	ttdestroy(r->a[0], freekey);
+	ttdestroy(r->a[1], freekey);
+	if (freekey) freekey((void *)r->key);
+	free(r);
+}
+
+void *ttfind(const void *key, void *const *rootp,
+	int(*cmp)(const void *, const void *))
+{
+	if (!rootp)
+		return 0;
+
+	struct node *n = *rootp;
+	for (;;) {
+		if (!n)
+			break;
+		int c = cmp(key, n->key);
+		if (!c)
+			break;
+		n = n->a[c>0];
+	}
+	return n;
+}
+
+static inline int height(struct node *n) { return n ? n->h : 0; }
+
+static int rot(void **p, struct node *x, int dir /* deeper side */)
+{
+	struct node *y = x->a[dir];
+	struct node *z = y->a[!dir];
+	int hx = x->h;
+	int hz = height(z);
+	if (hz > height(y->a[dir])) {
+		/*
+		 *   x
+		 *  / \ dir          z
+		 * A   y            / \
+		 *    / \   -->    x   y
+		 *   z   D        /|   |\
+		 *  / \          A B   C D
+		 * B   C
+		 */
+		x->a[dir] = z->a[!dir];
+		y->a[!dir] = z->a[dir];
+		z->a[!dir] = x;
+		z->a[dir] = y;
+		x->h = hz;
+		y->h = hz;
+		z->h = hz+1;
+	} else {
+		/*
+		 *   x               y
+		 *  / \             / \
+		 * A   y    -->    x   D
+		 *    / \         / \
+		 *   z   D       A   z
+		 */
+		x->a[dir] = z;
+		y->a[!dir] = x;
+		x->h = hz+1;
+		y->h = hz+2;
+		z = y;
+	}
+	*p = z;
+	return z->h - hx;
+}
+
+/* balance *p, return 0 if height is unchanged.  */
+static int __tsearch_balance(void **p)
+{
+	struct node *n = *p;
+	int h0 = height(n->a[0]);
+	int h1 = height(n->a[1]);
+	if (h0 - h1 + 1u < 3u) {
+		int old = n->h;
+		n->h = h0<h1 ? h1+1 : h0+1;
+		return n->h - old;
+	}
+	return rot(p, n, h0<h1);
+}
+
+void *ttsearch(const void *key, void **rootp,
+	int (*cmp)(const void *, const void *))
+{
+	if (!rootp)
+		return 0;
+
+	void **a[MAXH];
+	struct node *n = *rootp;
+	struct node *r;
+	int i=0;
+	a[i++] = rootp;
+	for (;;) {
+		if (!n)
+			break;
+		int c = cmp(key, n->key);
+		if (!c)
+			return n;
+		a[i++] = &n->a[c>0];
+		n = n->a[c>0];
+	}
+	r = malloc(sizeof *r);
+	if (!r)
+		return 0;
+	r->key = key;
+	r->a[0] = r->a[1] = 0;
+	r->h = 1;
+	/* insert new node, rebalance ancestors.  */
+	*a[--i] = r;
+	while (i && __tsearch_balance(a[--i]));
+	return r;
+}
+
+void *ttdelete(const void *restrict key, void **restrict rootp,
+	int(*cmp)(const void *, const void *))
+{
+	if (!rootp)
+		return 0;
+
+	void **a[MAXH+1];
+	struct node *n = *rootp;
+	struct node *parent;
+	struct node *child;
+	int i=0;
+	/* *a[0] is an arbitrary non-null pointer that is returned when
+	   the root node is deleted.  */
+	a[i++] = rootp;
+	a[i++] = rootp;
+	for (;;) {
+		if (!n)
+			return 0;
+		int c = cmp(key, n->key);
+		if (!c)
+			break;
+		a[i++] = &n->a[c>0];
+		n = n->a[c>0];
+	}
+	parent = *a[i-2];
+	if (n->a[0]) {
+		/* free the preceding node instead of the deleted one.  */
+		struct node *deleted = n;
+		a[i++] = &n->a[0];
+		n = n->a[0];
+		while (n->a[1]) {
+			a[i++] = &n->a[1];
+			n = n->a[1];
+		}
+		deleted->key = n->key;
+		child = n->a[0];
+	} else {
+		child = n->a[1];
+	}
+	/* freed node has at most one child, move it up and rebalance.  */
+	free(n);
+	*a[--i] = child;
+	while (--i && __tsearch_balance(a[i]));
+	return parent;
+}
+
+static void walk(const struct node *r, void (*action)(const void *, TVISIT, int), int d)
+{
+	if (!r)
+		return;
+	if (r->h == 1)
+		action(r, tleaf, d);
+	else {
+		action(r, tpreorder, d);
+		walk(r->a[0], action, d+1);
+		action(r, tpostorder, d);
+		walk(r->a[1], action, d+1);
+		action(r, tendorder, d);
+	}
+}
+
+void ttwalk(const void *root, void (*action)(const void *, TVISIT, int))
+{
+	walk(root, action, 0);
+}

--- a/src/musl_tsearch.h
+++ b/src/musl_tsearch.h
@@ -1,0 +1,16 @@
+#ifndef HEADER_DBD91B1DA09E43B1B27A0CE43D8B5E7B
+#define HEADER_DBD91B1DA09E43B1B27A0CE43D8B5E7B
+
+typedef enum { tpreorder, tpostorder, tendorder, tleaf } TVISIT;
+
+void ttdestroy(void *root, void (*freekey)(void *));
+
+void *ttfind(const void *key, void *const *rootp, int(*cmp)(const void *, const void *));
+
+void *ttsearch(const void *key, void **rootp, int (*cmp)(const void *, const void *));
+
+void *ttdelete(const void *restrict key, void **restrict rootp, int(*cmp)(const void *, const void *));
+
+void ttwalk(const void *root, void (*action)(const void *, TVISIT, int));
+
+#endif

--- a/src/profiler.c
+++ b/src/profiler.c
@@ -1,4 +1,5 @@
 #include <string.h>
+#include <inttypes.h>
 
 #include "profiler.h"
 
@@ -120,5 +121,5 @@ void profiler_output_helper(address_t *profile_counts, int show_bars, int show_o
       }
       ptr++;
    }
-   printf("     : %8ld cycles (%10.6f%%) %8ld ins (%4.2f cpi)\n", total_cycles, total_percent, total_instr, (double) total_cycles / (double) total_instr);
+   printf("     : %8" PRIu64 " cycles (%10.6f%%) %8" PRIu64 " ins (%4.2f cpi)\n", total_cycles, total_percent, total_instr, (double) total_cycles / (double) total_instr);
 }

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -115,6 +115,12 @@ else
     echo "Running basic tests:"
 fi
 
+if [[ `uname` = Darwin ]]; then
+  STATARGS=-f%z
+else
+  STATARGS=-c%s
+fi
+
 for data in "${data_names[@]}"
 do
     for machine in "${machine_names[@]}"
@@ -142,7 +148,7 @@ do
                 fi
                 fail_count=`grep fail ${log} | wc -l`
                 md5=`md5sum ${log} | cut -c1-8`
-                size=$(stat -c%s "${log}")
+                size=$(stat ${STATARGS} "${log}")
                 echo "  Trace MD5: ${md5}; Prediction fail count: ${fail_count}"
                 # Log some context around each failure (limit to 100 failures)
                 # Compare md5 of results with ref, rather than using diff, as diff can blow up


### PR DESCRIPTION
- tweak run_tests.sh to work with BSD-type tools

- add search.h code from musl, as OS X's libc doesn't support tdestroy,
  a GNU extension. Might as well then use this on all platforms

- avoid format string warnings by using inttypes.h where appropriate

- update build.sh with MacPorts logic. Hopefully Homebrew will just
  work as-is, since it puts everything in /usr/local...