### PR TITLE
Don't treat `STA`/`STX`/`STY` value written as authoritative.

### DIFF
--- a/src/em_6502.c
+++ b/src/em_6502.c
@@ -1634,8 +1634,9 @@ static int op_STA(operand_t operand, ea_t ea) {
       if (operand != A) {
          failflag = 1;
       }
+   } else {
+      A = operand;
    }
-   A = operand;
    return operand;
 }
 
@@ -1644,8 +1645,9 @@ static int op_STX(operand_t operand, ea_t ea) {
       if (operand != X) {
          failflag = 1;
       }
+   } else {
+      X = operand;
    }
-   X = operand;
    return operand;
 }
 
@@ -1654,8 +1656,9 @@ static int op_STY(operand_t operand, ea_t ea) {
       if (operand != Y) {
          failflag = 1;
       }
+   } else {
+      Y = operand;
    }
-   Y = operand;
    return operand;
 }
 


### PR DESCRIPTION
Seems that if the write is to a ROM, the snooped data bus value can be the value in the ROM rather than the value the CPU tried to write. Since write instructions never change the register's value, don't use the data bus value to update the register's assumed value if it already has one.

(It's still possible to end up with a wrong result - suppose the first evidence of the register's value is a write to a ROM? A future iteration of this change could improve this, I suppose, with some machine-specific logic. But this change better handles one not-uncommon case for BBC Micro stuff: writing to sideways ROM banks to test for RAM there.)